### PR TITLE
Resolution for issues with *_from_delta_in_seconds on Windows platforms

### DIFF
--- a/libcdatetime/libcdatetime_elements.c
+++ b/libcdatetime/libcdatetime_elements.c
@@ -2073,7 +2073,7 @@ int libcdatetime_elements_get_delta_in_seconds(
 			return( -1 );
 		}
 	}
-	*number_of_seconds = (int64_t) time_delta;
+	*number_of_seconds = ((int64_t) time_delta) / 10000000L;
 
 	return( 1 );
 }
@@ -2206,6 +2206,9 @@ int libcdatetime_elements_set_from_delta_in_seconds(
 /* TODO mark duration as negative ? */
 		number_of_seconds *= -1;
 	}
+	
+	number_of_seconds *= 10000000L;
+	
 	internal_elements->filetime.dwHighDateTime = (DWORD) ( ( number_of_seconds >> 32 ) & 0xffffffffUL );
 	internal_elements->filetime.dwLowDateTime  = (DWORD) ( number_of_seconds & 0xffffffffUL );
 


### PR DESCRIPTION
`libcdatetime_elements_get_delta_in_seconds()` and `libcdatetime_elements_set_delta_in_seconds()` fail to account for the difference in timestamp resolution between *nix and Windows platforms.

`number_of_seconds` needs to be scaled by TICKS_PER_SECOND on Windows platforms to convert from system ticks (10ns intervals) to seconds.

This causes the ewftools on windows to incorrectly report acquisition/verification durations.  More importantly, it means that progress indications are sent after _EVERY_ block compression in ewfacquirestream.  When acquiring using small block sizes (e.g. 32K)  the number of updates is so high that it dramatically slows down the acquisition.

Applying this patch fixes the problem and allows ewf acquisition on Windows to be performed quickly at small block sizes.
